### PR TITLE
Add minimal, ReSpec-enabled doc, hinting major sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+
+<html lang="en-GB">
+
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"    content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Documentation on how to use GitHub to work on W3C specifications and projects">
+    <meta name="author"      content="World Wide Web Consortium (W3C) http://www.w3.org/">
+    <meta name="keywords"    content="W3C,w3.org,GitHub,GH,howto,documentation,specification,project,spec,guide">
+    <title>Using GitHub at W3C</title>
+    <script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common.js" class="remove"></script>
+
+    <script type="text/javascript" class="remove">
+      var respecConfig = {
+        specStatus: 'unofficial',
+        shortName:  'using-github',
+        editors:    [
+          {
+            name: 'Philippe Le Hegaret',
+            url: 'https://github.com/plehegar'
+          }
+        ]
+      };
+    </script>
+
+  </head>
+
+  <body>
+
+    <section id="abstract">
+      <p>Documentation on how to use GitHub to work on <abbr title="World Wide Web Consortium">W3C</abbr> specifications and projects.</p>
+      <p>Refer to <a href="https://github.com/w3c/using-github">the GitHub repository</a> for more information.</p>
+    </section>
+
+    <section id="sotd">
+    </section>
+
+    <section class="informative">
+      <h2>Scope</h2>
+    </section>
+
+    <section>
+      <h2>Requirements</h2>
+      <section>
+        <h2>Ability to archive permanently</h2>
+      </section>
+      <section>
+        <h2>Owning the [meta]data</h2>
+      </section>
+      <section>
+        <h2>Streamlining collaboration: minimum staff intervention</h2>
+      </section>
+      <section>
+        <h2>Keeping track of contributors</h2>
+      </section>
+    </section>
+
+    <section>
+      <h2>Using branches</h2>
+    </section>
+
+    <section>
+      <h2>Commenting and tagging</h2>
+    </section>
+
+    <section>
+      <h2>Integration of tools</h2>
+      <section>
+        <h2>GitHub</h2>
+      </section>
+      <section>
+        <h2>Echidna and the automatic publication workflow</h2>
+      </section>
+      <section>
+        <h2>Travis</h2>
+      </section>
+    </section>
+
+    <section>
+      <h2>Horizontal issues</h2>
+      <p>eg, related to <abbr title="internationalisation">i18n</abbr>.</p>
+    </section>
+
+    <section>
+      <h2>Handling <abbr title="pull request">PR</abbr>s</h2>
+    </section>
+
+    <section>
+      <h2>Permissions: how has push access?</h2>
+    </section>
+
+    <section>
+      <h2>Provided boilerplate</h2>
+      <section>
+        <h2><code>CONTRIBUTING.md</code></h2>
+      </section>
+    </section>
+
+  </body>
+
+</html>
+


### PR DESCRIPTION
So far we have been using this repo merely as a discussion forum.

``` bash
$ touch index.html
```

I have made a few assumptions (picked a title, @plehegar as the editor, ReSpec as the tool of choice&hellip;). And I have added a few `<h2>`s based on the [issues we are discussing](https://github.com/w3c/using-github/issues). Of course, feel free to correct these details, and add content, directly in this branch.
